### PR TITLE
fix(firebase): corrigida a importação da chave privada

### DIFF
--- a/src/shared/infra/firestore/firebase.ts
+++ b/src/shared/infra/firestore/firebase.ts
@@ -2,10 +2,12 @@ import { initializeApp, cert, ServiceAccount } from 'firebase-admin/app';
 
 // ---------------------------------------------------------------------------------------------- //
 
+const { privateKey } = JSON.parse(process.env.PRIVATE_KEY as string);
+
 const serviceAccount: ServiceAccount = {
   projectId: process.env.PROJECT_ID,
   clientEmail: process.env.CLIENT_EMAIL,
-  privateKey: process.env.PRIVATE_KEY
+  privateKey
 };
 
 const testServiceAccount = {


### PR DESCRIPTION
Não existia nenhum problema com as variáveis de ambiente na máquina
local, mas sim ao fazer o deploy no heroku.

O heroku remove as (") das variáveis de ambiente. O que gerava o crash
na execução do servidor.

A configuração do firebase foi alterada para receber um json, assim não
importa o comportamento do heroku em relação as variáveis de ambiente.